### PR TITLE
feat: alias `SmartBuffer` as `SmartArrayBuffer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ import { SmartBuffer } from 'smart-arraybuffer';
 
 // Typescript
 import { SmartBuffer, SmartBufferOptions} from 'smart-arraybuffer';
+
+// Or if you want to emphasize that you're using smart-arraybuffer instead of smart-buffer
+import { SmartArrayBuffer } from 'smart-arraybuffer';
+console.log(SmartArrayBuffer === SmartBuffer); // true
 ```
 
 ### Simple Example

--- a/src/smart-arraybuffer.ts
+++ b/src/smart-arraybuffer.ts
@@ -1615,4 +1615,4 @@ class SmartBuffer {
   }
 }
 
-export { SmartBufferOptions, SmartBuffer };
+export { SmartBufferOptions, SmartBuffer, SmartBuffer as SmartArrayBuffer };


### PR DESCRIPTION
If you want to emphasize that you're using `smart-arraybuffer` instead of `smart-buffer`, you can now also import using
```js
import { SmartArrayBuffer } from 'smart-arraybuffer';
```
